### PR TITLE
Update deploy-openshift4-vsphere.tfvars.template

### DIFF
--- a/deploy-openshift4-vsphere.tfvars.template
+++ b/deploy-openshift4-vsphere.tfvars.template
@@ -85,7 +85,7 @@ external_network_name = "Public Network"
 # port group.
 
 private_network_dvs_name     = "Plot01 Cluster Networks DVSwitch"
-private_network_vlan_number  = 902
+private_network_vlan_number  = 901
 use_private_internal_network = true
 
 # --- Virtual Machine Properties ---


### PR DESCRIPTION
Standardizing the OCP dynamic VLAN number to correspond with the keg IP:
IP: 139.178.67.XX or .1XX => VLAN 9XX